### PR TITLE
Ts enable client credentials grant for bearer tokens and integrate users client

### DIFF
--- a/manage-auth/Program.cs
+++ b/manage-auth/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddSingleton<IRequestValidator, RequestValidator>();
 builder.Services.AddSingleton<IAuthRepository, AuthRepository>();
 builder.Services.AddSingleton<IAuthDataservice, AuthDataservice>();
 builder.Services.AddSingleton<ICognitoClient, CognitoClient>();
+builder.Services.AddSingleton<IUsersClient, UsersClient>();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -45,6 +46,18 @@ builder.Services.AddSwaggerGen(options =>
                     },
         });
     });
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll",
+        builder =>
+        {
+            // Allow all origins, methods, and headers
+            builder.AllowAnyOrigin()
+                   .AllowAnyMethod()
+                   .AllowAnyHeader();
+        });
+});
 
 
 var userPoolId = configuration["AWS:Cognito:UserPoolId"];
@@ -79,6 +92,8 @@ if (app.Environment.IsDevelopment())
     });
     // app.UseDeveloperExceptionPage();
 }
+
+app.UseCors("AllowAll");
 
 app.UseHttpsRedirection();
 

--- a/manage-auth/manage-auth.sln
+++ b/manage-auth/manage-auth.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "manage-auth", "manage-auth.csproj", "{CE77E16E-A404-4E67-AFC1-40DC80C70AD5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CE77E16E-A404-4E67-AFC1-40DC80C70AD5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE77E16E-A404-4E67-AFC1-40DC80C70AD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE77E16E-A404-4E67-AFC1-40DC80C70AD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE77E16E-A404-4E67-AFC1-40DC80C70AD5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {48BA6512-A1D4-42CB-97D4-036BB9964FF6}
+	EndGlobalSection
+EndGlobal

--- a/manage-auth/src/clients/IUsersClient.cs
+++ b/manage-auth/src/clients/IUsersClient.cs
@@ -6,5 +6,7 @@ namespace manage_auth.src.clients
     public interface IUsersClient
     { 
         public Task<HttpResponseMessage> CreateUser(CreateUserRequest createUserRequest, string bearerToken);
+        
+        public Task<User> GetUser(string email, string bearerToken);
     }
 }

--- a/manage-auth/src/clients/IUsersClient.cs
+++ b/manage-auth/src/clients/IUsersClient.cs
@@ -1,0 +1,10 @@
+using manage_auth.src.models;
+using manage_auth.src.models.requests;
+
+namespace manage_auth.src.clients
+{
+    public interface IUsersClient
+    { 
+        public Task<HttpResponseMessage> CreateUser(CreateUserRequest createUserRequest, string bearerToken);
+    }
+}

--- a/manage-auth/src/clients/UsersClient.cs
+++ b/manage-auth/src/clients/UsersClient.cs
@@ -2,8 +2,6 @@
 using System.Net.Http.Headers;
 using manage_auth.src.models;
 using manage_auth.src.models.requests;
-using Microsoft.AspNetCore.Mvc;
-using Org.BouncyCastle.Asn1;
 
 namespace manage_auth.src.clients
 {
@@ -38,6 +36,13 @@ namespace manage_auth.src.clients
             {
                 throw new Exception(response.ReasonPhrase);
             }
+        }
+        
+        public async Task<User> GetUser(string email, string bearerToken)
+        {
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken.ToString());
+            var response = await _client.GetFromJsonAsync<User>($"/api/Users/email/{email}");
+            return response;
         }
     }
 }

--- a/manage-auth/src/clients/UsersClient.cs
+++ b/manage-auth/src/clients/UsersClient.cs
@@ -1,0 +1,43 @@
+
+using System.Net.Http.Headers;
+using manage_auth.src.models;
+using manage_auth.src.models.requests;
+using Microsoft.AspNetCore.Mvc;
+using Org.BouncyCastle.Asn1;
+
+namespace manage_auth.src.clients
+{
+    public class UsersClient : IUsersClient
+    {
+        private IConfiguration _configuration;
+        private readonly HttpClient _client;
+
+        public UsersClient(IConfiguration configuration)
+        {
+            _configuration = configuration;
+            _client = new HttpClient
+            {
+                BaseAddress = new Uri(_configuration.GetConnectionString("ManageUsersLocalConnection"))
+            };
+            _client.DefaultRequestHeaders.Accept.Clear();
+            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        }
+
+        public async Task<HttpResponseMessage> CreateUser(CreateUserRequest createUserRequest, string bearerToken)
+        {
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken.ToString());
+            HttpResponseMessage response = await _client.PostAsJsonAsync<CreateUserRequest>($"/api/Users", createUserRequest);
+
+            if (response.IsSuccessStatusCode)
+            {
+                // var responseData = await response.Content.ReadAsStringAsync();
+                // return responseData;
+                return response;
+            }
+            else 
+            {
+                throw new Exception(response.ReasonPhrase);
+            }
+        }
+    }
+}

--- a/manage-auth/src/clients/UsersClient.cs
+++ b/manage-auth/src/clients/UsersClient.cs
@@ -28,8 +28,6 @@ namespace manage_auth.src.clients
 
             if (response.IsSuccessStatusCode)
             {
-                // var responseData = await response.Content.ReadAsStringAsync();
-                // return responseData;
                 return response;
             }
             else 

--- a/manage-auth/src/controller/AuthController.cs
+++ b/manage-auth/src/controller/AuthController.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Http.Headers;
-using System.Text;
 using manage_auth.src.clients;
 using manage_auth.src.models;
 using manage_auth.src.models.errors;

--- a/manage-auth/src/controller/AuthController.cs
+++ b/manage-auth/src/controller/AuthController.cs
@@ -1,8 +1,13 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
 using manage_auth.src.clients;
+using manage_auth.src.models;
+using manage_auth.src.models.errors;
 using manage_auth.src.models.requests;
-using manage_auth.src.repository;
 using manage_auth.src.util;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 
 namespace manage_auth.src.controller
 {
@@ -11,14 +16,19 @@ namespace manage_auth.src.controller
     public class AuthController : Controller
     {
         IRequestValidator _validator;
-        IAuthRepository _authRepository;
+        IConfiguration _configuration;
         ICognitoClient _cognitoClient;
+        IUsersClient _usersClient;
 
-        public AuthController(IAuthRepository authRepository, IRequestValidator requestValidator, ICognitoClient cognitoClient)
+        public AuthController(IRequestValidator requestValidator, 
+                              IConfiguration configuration,
+                              ICognitoClient cognitoClient, 
+                              IUsersClient usersClient)
         {
             _validator = requestValidator;
-            _authRepository = authRepository;
+            _configuration = configuration;
             _cognitoClient = cognitoClient;
+            _usersClient = usersClient;
         }
 
         [HttpGet]
@@ -33,8 +43,7 @@ namespace manage_auth.src.controller
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error: {ex.Message}");
-                    throw;
+                    return InternalError(ex.Message);
                 }
             }
             else
@@ -55,8 +64,7 @@ namespace manage_auth.src.controller
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error: {ex.Message}");
-                    throw;
+                    return InternalError(ex.Message);
                 }
             }
             else
@@ -66,7 +74,7 @@ namespace manage_auth.src.controller
         }
 
         [HttpPost("user/authenticate")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(AuthResponse), StatusCodes.Status200OK)]
         public async Task<IActionResult> AuthenticateUser(AuthenticateUserRequest authenticateUserRequest)
         {
             if (_validator.ValidateAuthenticateUser(authenticateUserRequest))
@@ -74,35 +82,40 @@ namespace manage_auth.src.controller
                 try
                 {
                     var authResponse = await _cognitoClient.AuthenticateUserAsync(authenticateUserRequest);
-                    return Ok(authResponse);
+                    var response = new AuthResponse()
+                    {
+                        AuthenticationResult = authResponse.AuthenticationResult,
+                        Status = authResponse.HttpStatusCode
+                    };
+                    return Ok(response);
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error: {ex.Message}");
-                    throw;
+                    return InternalError(ex.Message);
                 }
             }
             else
             {
-                return BadRequest("CreateUserRequest is required.");
+                return BadRequest("AuthenticateUserRequest is required.");
             }
         }
 
         [HttpPost("user")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async Task<IActionResult> RegisterUser(CreateUser createUserRequest)
+        public async Task<IActionResult> RegisterUser(CreateUserRequest createUserRequest)
         {
             if (_validator.ValidateCreateUser(createUserRequest))
             {
                 try
                 {
                     await _cognitoClient.SignUpUserAsync(createUserRequest.Email, createUserRequest.Password, createUserRequest.FirstName, createUserRequest.LastName);
+                    var bearerToken = await GetBearerToken();
+                    await _usersClient.CreateUser(createUserRequest, bearerToken.access_token);
                     return Ok();
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error: {ex.Message}");
-                    throw;
+                    return InternalError(ex.Message);
                 }
             }
             else
@@ -124,14 +137,81 @@ namespace manage_auth.src.controller
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error: {ex.Message}");
-                    throw;
+                    return InternalError(ex.Message);
                 }
             }
             else
             {
-                return BadRequest("CreateUserRequest is required.");
+                return BadRequest("ConfirmUserRequest is required.");
             }
         }
+
+        #region HELPERS
+
+        private async Task<TokenResponse> GetBearerToken()
+        {
+            var clientId = _configuration["AWS:Cognito:ClientId"];
+            var clientSecret = _configuration["AWS:Cognito:ClientSecret"];
+            var cognitoDomain = _configuration["AWS:Cognito:Domain"];
+            // var tokenEndpoint = _configuration["AWS:Cognito:TokenEndpoint"];
+            var region = _configuration["AWS:Cognito:Region"];
+            var userPoolId = _configuration["AWS:Cognito:UserPoolId"];
+
+            var tokenEndpoint = $"https://projectb-userpool-dev.auth.us-east-1.amazoncognito.com/oauth2/token";
+            var scope = "openid";
+
+            var client = new HttpClient();
+            
+            // Prepare the request data
+            var requestData = new
+            {
+                grant_type = "client_credentials",
+                client_id = clientId,
+                client_secret = clientSecret
+            };
+
+            var content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("grant_type", "client_credentials"),
+                new KeyValuePair<string, string>("client_id", clientId),
+                new KeyValuePair<string, string>("client_secret", clientSecret)
+            });
+
+            // Set the Content-Type header
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
+
+            // var content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, "application/json");
+            
+            // Send the request
+            var response = await client.PostAsync(tokenEndpoint, content);
+            
+            // Handle the response
+            if (response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                var tokenResponse = JsonConvert.DeserializeObject<TokenResponse>(responseBody);
+                Console.WriteLine("Bearer Token: " + tokenResponse.access_token);
+                return tokenResponse;
+            }
+            else
+            {
+                var err = response.ReasonPhrase;
+                Console.WriteLine("Error: " + err);
+                throw new Exception(err);
+            }
+        }
+        
+        private ObjectResult InternalError(string message)
+        {
+            var errorResponse = new ErrorResponse
+            {
+                Status = HttpStatusCode.InternalServerError,
+                Type = "InternalServerError",
+                Detail = message
+            };
+            return StatusCode(StatusCodes.Status500InternalServerError, errorResponse);
+        }
+
+        #endregion 
     }
 }

--- a/manage-auth/src/models/AuthResponse.cs
+++ b/manage-auth/src/models/AuthResponse.cs
@@ -1,0 +1,13 @@
+using Amazon.CognitoIdentityProvider.Model;
+
+namespace manage_auth.src.models
+{
+    public class AuthResponse : ResponseBase
+    {
+        public AuthResponse()
+        {
+            Type = "AuthResponse";
+        }
+        public AuthenticationResultType AuthenticationResult { get; set; }
+    }
+}

--- a/manage-auth/src/models/AuthenticationResponse.cs
+++ b/manage-auth/src/models/AuthenticationResponse.cs
@@ -2,12 +2,14 @@ using Amazon.CognitoIdentityProvider.Model;
 
 namespace manage_auth.src.models
 {
-    public class AuthResponse : ResponseBase
+    public class AuthenticationResponse : ResponseBase
     {
-        public AuthResponse()
+        public AuthenticationResponse()
         {
-            Type = "AuthResponse";
+            Type = "AuthenticationResponse";
         }
+        
         public AuthenticationResultType AuthenticationResult { get; set; }
+        public User User { get; set; }
     }
 }

--- a/manage-auth/src/models/ResponseBase.cs
+++ b/manage-auth/src/models/ResponseBase.cs
@@ -1,12 +1,11 @@
+using System.Net;
+
 namespace manage_auth.src.models
 {
     public class ResponseBase
     {
-        public ResponseBase()
-        {
-
-        }
-
-        public int StatusCode;
+        public HttpStatusCode Status { get; set; }
+        public string Type { get; set; }
+        public string Detail { get; set; }
     }
 }

--- a/manage-auth/src/models/TokenResponse.cs
+++ b/manage-auth/src/models/TokenResponse.cs
@@ -1,0 +1,9 @@
+namespace manage_auth.src.models
+{
+    class TokenResponse
+    {
+        public string access_token { get; set; }
+        public string token_type { get; set; }
+        public int expires_in { get; set; }
+    }
+}

--- a/manage-auth/src/models/User.cs
+++ b/manage-auth/src/models/User.cs
@@ -1,0 +1,26 @@
+using Amazon.CognitoIdentityProvider.Model;
+
+namespace manage_auth.src.models
+{
+    public class User : ResponseBase
+    {
+        public User()
+        {
+
+        }
+
+        public int UserId { get; set; }
+
+        public string Email { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        public DateTime CreateDatetime { get; set; }
+
+        public DateTime? UpdateDatetime { get; set; }
+
+        public int? UpdateUserId { get; set; }
+    }
+}

--- a/manage-auth/src/models/errors/ErrorResponse.cs
+++ b/manage-auth/src/models/errors/ErrorResponse.cs
@@ -1,0 +1,8 @@
+using System.Net;
+
+namespace manage_auth.src.models.errors
+{
+    public class ErrorResponse : ResponseBase
+    {
+    }
+}

--- a/manage-auth/src/models/requests/CreateUserRequest.cs
+++ b/manage-auth/src/models/requests/CreateUserRequest.cs
@@ -1,8 +1,8 @@
 namespace manage_auth.src.models.requests
 {
-    public class CreateUser
+    public class CreateUserRequest
     {
-        public CreateUser()
+        public CreateUserRequest()
         {
 
         }
@@ -14,9 +14,5 @@ namespace manage_auth.src.models.requests
         public string FirstName { get; set; }
 
         public string LastName { get; set; }
-
-        public string PhoneNumber { get; set; }
-
-        public string Address { get; set; }
     }
 }

--- a/manage-auth/src/util/RequestValidator.cs
+++ b/manage-auth/src/util/RequestValidator.cs
@@ -10,7 +10,7 @@ namespace manage_auth.src.util
         
         bool ValidateAuthenticateRequest(AuthenticateRequest authenticateRequestRequest);
 
-        bool ValidateCreateUser(CreateUser createUserRequest);
+        bool ValidateCreateUser(CreateUserRequest createUserRequest);
         
         bool ValidateConfirmUser(ConfirmUserRequest confirmUserRequest);
 
@@ -40,7 +40,7 @@ namespace manage_auth.src.util
             return true;
         }
 
-        public bool ValidateCreateUser(CreateUser createUserRequest)
+        public bool ValidateCreateUser(CreateUserRequest createUserRequest)
         {
             return true;
         }


### PR DESCRIPTION
- Enabled client credentials grant auth flow on the user pool, so can now use app client data to generate bearer token for M2M auth without needing user credentials
- Integrated manage-users to A) create a new user record on signup and B) retrieve user record for user session on login